### PR TITLE
Detect flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,44 +1,28 @@
-# Detect if running in GitHub Actions
+# First, check if running on GitHub Actions
 if (DEFINED ENV{GITHUB_ACTIONS} AND "$ENV{GITHUB_ACTIONS}" STREQUAL "true")
     message(STATUS "Running on GitHub Actions runner.")
     set(IS_GITHUB_ACTIONS ON)
 endif ()
 
-# Step 1: Check compiler support for AVX-512DQ
+# Check if the compiler supports -mavx512dq
 check_cxx_compiler_flag("-mavx512dq" COMPILER_SUPPORTS_AVX512DQ)
 
-if (COMPILER_SUPPORTS_AVX512DQ)
-    message(STATUS "Compiler supports AVX-512DQ.")
-
-    # Write the test program to check for AVX-512DQ support
-    file(WRITE "${CMAKE_BINARY_DIR}/check_avx512dq.cpp"
-            "#include <immintrin.h>
-        int main() {
-            __m512d x = _mm512_set1_pd(1.0); // AVX-512DQ specific intrinsic for double-precision
-            return 0;
-        }"
-            )
-
-    try_compile(HAS_AVX512DQ_SUPPORT
-            "${CMAKE_BINARY_DIR}"
-            "${CMAKE_BINARY_DIR}/check_avx512dq.cpp"
-            COMPILE_DEFINITIONS -mavx512dq
-            )
-
-    if (HAS_AVX512DQ_SUPPORT AND NOT IS_GITHUB_ACTIONS)
-        message(STATUS "Hardware supports AVX-512DQ. Adding AVX-512DQ flags.")
-        set(AVX512DQ_FLAG "-mavx512dq")
-    elseif (HAS_AVX512DQ_SUPPORT AND IS_GITHUB_ACTIONS)
-        message(WARNING "AVX-512DQ is supported, but flags will not be added on GitHub Actions runner.")
-    else ()
-        message(STATUS "Hardware does not support AVX-512DQ.")
+# Detect AVX-512DQ hardware support via /proc/cpuinfo
+set(HAS_HW_AVX512DQ OFF)
+if (EXISTS "/proc/cpuinfo")
+    file(READ "/proc/cpuinfo" CPUINFO_CONTENT)
+    if (CPUINFO_CONTENT MATCHES "avx512dq")
+        set(HAS_HW_AVX512DQ ON)
     endif ()
+endif ()
+
+if (COMPILER_SUPPORTS_AVX512DQ AND HAS_HW_AVX512DQ AND NOT IS_GITHUB_ACTIONS)
+    message(STATUS "Compiler and hardware both support AVX-512DQ. Adding flag.")
+    set(AVX512DQ_FLAG "-mavx512dq")
+elseif (COMPILER_SUPPORTS_AVX512DQ AND HAS_HW_AVX512DQ AND IS_GITHUB_ACTIONS)
+    message(WARNING "Hardware supports AVX-512DQ, but not adding on GitHub Actions runner.")
 else ()
-    if (IS_GITHUB_ACTIONS)
-        message(WARNING "Compiler on GitHub Actions runner does not support AVX-512DQ.")
-    else ()
-        message(STATUS "Compiler does not support AVX-512DQ.")
-    endif ()
+    message(STATUS "AVX-512DQ is not fully supported (either by compiler or hardware).")
 endif ()
 
 # Define the library

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,13 +17,17 @@ if (EXISTS "/proc/cpuinfo")
 endif ()
 
 if (COMPILER_SUPPORTS_AVX512DQ AND HAS_HW_AVX512DQ AND NOT IS_GITHUB_ACTIONS)
-    message(STATUS "Compiler and hardware both support AVX-512DQ. Adding flag.")
-    set(AVX512DQ_FLAG "-mavx512dq")
+    message(STATUS "Compiler and hardware both support AVX-512DQ. Adding flag '-mavx512dq'.")
+    set(FLAGS "-mavx512dq")
 elseif (COMPILER_SUPPORTS_AVX512DQ AND HAS_HW_AVX512DQ AND IS_GITHUB_ACTIONS)
     message(WARNING "Hardware supports AVX-512DQ, but not adding on GitHub Actions runner.")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|i[3-6]86")
+    message(STATUS "Setting '-march=native' for x86 processors without AVX-512DQ.")
+    set(FLAGS "-march=native")
 else ()
-    message(STATUS "AVX-512DQ is not fully supported (either by compiler or hardware).")
+    message(STATUS "No instruction set flags applied.")
 endif ()
+
 
 # Define the library
 add_library(ALP
@@ -33,9 +37,9 @@ add_library(ALP
         fastlanes_generated_ffor.cpp
         fastlanes_ffor.cpp
         fastlanes_unffor.cpp
-        )
+)
 
 # Add AVX-512DQ flag if supported and not on GitHub Actions
-if (AVX512DQ_FLAG)
-    target_compile_options(ALP PUBLIC ${AVX512DQ_FLAG})
+if (FLAGS)
+    target_compile_options(ALP PUBLIC ${FLAGS})
 endif ()


### PR DESCRIPTION
- Detect AVX-512DQ hardware support via /proc/cpuinfo
- Setting '-march=native' for x86 processors without AVX-512DQ